### PR TITLE
feat: Add RECO status endpoint

### DIFF
--- a/app/integrations/reco_api.py
+++ b/app/integrations/reco_api.py
@@ -118,3 +118,42 @@ if __name__ == '__main__':
         logger.info(f"Status: {result['status']}")
         logger.info(f"Source: {result['source']}")
         logger.info(f"Last Checked: {time.ctime(result['last_checked'])}")
+
+
+def check_reco_registration_status(reco_number: str):
+    """
+    Checks the registration status of a RECO number.
+
+    Args:
+        reco_number: The RECO number to check.
+
+    Returns:
+        "REGISTERED" if the RECO number is registered, "INACTIVE_OR_INVALID" otherwise.
+    """
+    if not reco_number:
+        logger.error("RECO number cannot be empty.")
+        return "INACTIVE_OR_INVALID"
+
+    url = f"https://registrantsearch.reco.on.ca/api/Registrant/{reco_number}"
+    logger.info(f"Checking RECO registration status for {reco_number} at {url}")
+
+    try:
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()  # Raise an exception for bad status codes (4xx or 5xx)
+    except requests.exceptions.RequestException as e:
+        logger.error(f"Error during request to RECO API for {reco_number}: {e}")
+        return "INACTIVE_OR_INVALID"
+
+    try:
+        data = response.json()
+    except ValueError as e: # Catches JSONDecodeError as ValueError is its parent
+        logger.error(f"Error parsing JSON response from RECO API for {reco_number}: {e}")
+        logger.debug(f"Response text: {response.text}")
+        return "INACTIVE_OR_INVALID"
+
+    if data.get("registrationStatus") == "REGISTERED":
+        logger.info(f"RECO number {reco_number} is REGISTERED.")
+        return "REGISTERED"
+    else:
+        logger.info(f"RECO number {reco_number} is INACTIVE_OR_INVALID or status not found. Status: {data.get('registrationStatus')}")
+        return "INACTIVE_OR_INVALID"

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from app.database import init_db, get_db_connection
 from app.core_logic import perform_license_validation_sweep, get_last_run_results, get_all_alerts
 from app.notifications import send_notification_for_lapsed_licenses_db
 from app.integrations.wicket_api import check_wicket_api_health
+from app.integrations.reco_api import check_reco_registration_status
 
 IS_TEST_ENVIRONMENT = os.environ.get("FLASK_TESTING", "false").lower() == "true"
 
@@ -156,6 +157,16 @@ def resend_alert_route():
         return render_template('_alert_row.html', alert=final_alert_status_dict), 500
     finally:
         if conn: conn.close()
+
+@app.route('/reco/status/<reco_number>', methods=['GET'])
+def reco_status_route(reco_number: str):
+    """
+    Checks the RECO registration status for a given RECO number.
+    Returns a JSON response with the registration status.
+    """
+    app.logger.info(f"Received request for /reco/status/{reco_number}")
+    status = check_reco_registration_status(reco_number)
+    return jsonify({"registrationStatus": status})
 
 if __name__ == '__main__':
     # Set FLASK_ENV for development to enable debug mode (though app.run(debug=True) also does this)

--- a/app/tests/__init__.py
+++ b/app/tests/__init__.py
@@ -1,0 +1,1 @@
+# This file makes Python treat the `tests` directory as a package.

--- a/app/tests/test_main_routes.py
+++ b/app/tests/test_main_routes.py
@@ -1,0 +1,75 @@
+import unittest
+import json
+from unittest.mock import patch
+from app.main import app # Import the Flask app instance
+
+class TestRecoEndpoint(unittest.TestCase):
+
+    def setUp(self):
+        """Set up test client for each test."""
+        app.testing = True  # Enable testing mode
+        self.client = app.test_client()
+        # Ensure the app context is pushed if your app uses it during setup
+        # self.app_context = app.app_context()
+        # self.app_context.push()
+
+    def tearDown(self):
+        """Clean up after each test."""
+        # if self.app_context:
+        #     self.app_context.pop()
+        pass
+
+    @patch('app.main.check_reco_registration_status') # Patch where it's used in main.py
+    def test_reco_status_registered(self, mock_check_status):
+        """Test /reco/status/<reco_number> when registrant is REGISTERED."""
+        mock_check_status.return_value = "REGISTERED"
+
+        response = self.client.get('/reco/status/12345')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'application/json')
+
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data.get("registrationStatus"), "REGISTERED")
+        mock_check_status.assert_called_once_with("12345")
+
+    @patch('app.main.check_reco_registration_status') # Patch where it's used in main.py
+    def test_reco_status_inactive_or_invalid(self, mock_check_status):
+        """Test /reco/status/<reco_number> when registrant is INACTIVE_OR_INVALID."""
+        mock_check_status.return_value = "INACTIVE_OR_INVALID"
+
+        response = self.client.get('/reco/status/67890')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'application/json')
+
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data.get("registrationStatus"), "INACTIVE_OR_INVALID")
+        mock_check_status.assert_called_once_with("67890")
+
+    # Example of how you might test for an empty RECO number if the endpoint handled it specifically
+    # (though in our current design, check_reco_registration_status handles empty input,
+    # so the endpoint will still return what that function returns)
+    @patch('app.main.check_reco_registration_status')
+    def test_reco_status_empty_reco_number(self, mock_check_status):
+        """Test /reco/status/ with an effectively empty RECO number if needed,
+           or how the current system handles it via the mocked function."""
+        # Let's assume check_reco_registration_status itself handles empty strings
+        # by returning "INACTIVE_OR_INVALID" as per its implementation.
+        mock_check_status.return_value = "INACTIVE_OR_INVALID" # Simulating behavior for empty/bad input
+
+        # Test with an empty string path segment if the route could match it,
+        # or a placeholder that signifies an invalid RECO number.
+        # Flask might not route an empty segment as a path parameter by default.
+        # Let's use a placeholder like "invalid_reco" for the test path.
+        response = self.client.get('/reco/status/invalid_reco_placeholder')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content_type, 'application/json')
+        data = json.loads(response.data.decode('utf-8'))
+        self.assertEqual(data.get("registrationStatus"), "INACTIVE_OR_INVALID")
+        mock_check_status.assert_called_once_with("invalid_reco_placeholder")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a new endpoint `/reco/status/<reco_number>` that checks the registration status of a RECO licensee.

The endpoint uses the RECO API `https://registrantsearch.reco.on.ca/api/Registrant/<RECO_NUMBER>`. It returns `{"registrationStatus": "REGISTERED"}` if the registrant is actively registered, and `{"registrationStatus": "INACTIVE_OR_INVALID"}` otherwise.

Includes:
- New function `check_reco_registration_status` in `app.integrations.reco_api`.
- New route in `app.main` pointing to this function.
- Unit tests for the new endpoint, mocking the integration call.